### PR TITLE
[Fix] 네비게이션 바와 콘텐츠의 크기가 안 맞는 오류 수정

### DIFF
--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -12,7 +12,7 @@ interface DropdownProps {
 }
 
 const NavbarBlock = styled.nav`
-  width: 100vw;
+  width: 100%;
   position: fixed;
   z-index: 999;
   background-color: ${({ theme }) => theme.colors.white};


### PR DESCRIPTION
### 관련 이슈
- close #50

### PR Checklist
- [x] 원인이 무엇이었는지 코드를 통해 확인
- [x] 콘텐츠의 크기와 네비게이션 바의 크기가 잘 맞는지 확인

### 테스트 결과
<img width="1111" alt="스크린샷 2023-09-12 오전 1 46 11" src="https://github.com/Kusitms-28th-Hicardi-C/FrontEnd/assets/77859988/553416ed-eaac-41fc-903b-cc7d8bb49cf9">

