### PR TITLE
[Fix] 구매 정보 페이지 입력창 사이즈 오류 수정

### DIFF
--- a/src/components/auth/Information.tsx
+++ b/src/components/auth/Information.tsx
@@ -129,7 +129,7 @@ const Information = () => {
 
         <Content>
           <SubTitle>주소</SubTitle>
-          <Address />
+          <Address fullWidth />
         </Content>
 
         <Content>

--- a/src/components/common/Input/Address.tsx
+++ b/src/components/common/Input/Address.tsx
@@ -29,7 +29,6 @@ const BigInput = styled(AddressInput)<AddressProps>`
       : css`
           width: 20rem;
         `};
-  /* width: ${({ fullWidth }) => (fullWidth ? '100%' : '20rem')}; */
 `;
 
 const BigWhiteInput = styled(Input)<AddressProps>`
@@ -41,7 +40,6 @@ const BigWhiteInput = styled(Input)<AddressProps>`
       : css`
           width: 20rem;
         `};
-  /* width: ${({ fullWidth }) => (fullWidth ? '100%' : '20rem')}; */
 `;
 
 const Address = ({ fullWidth }: AddressProps) => {

--- a/src/components/common/Input/Address.tsx
+++ b/src/components/common/Input/Address.tsx
@@ -10,6 +10,7 @@ const AddressStyle = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  width: 100%;
 `;
 
 const AddressInput = styled(Input)`

--- a/src/components/common/Input/Address.tsx
+++ b/src/components/common/Input/Address.tsx
@@ -1,16 +1,15 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import DoubleCheckButton from '../Button/DoubleCheckButton';
 import Input from './Input';
 
 interface AddressProps {
-  width?: boolean;
+  fullWidth?: boolean;
 }
 
 const AddressStyle = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  width: 100%;
 `;
 
 const AddressInput = styled(Input)`
@@ -22,22 +21,38 @@ const SmallInput = styled(AddressInput)`
 `;
 
 const BigInput = styled(AddressInput)<AddressProps>`
-  width: ${({ width }) => (width ? '100%' : '20rem')};
+  ${({ fullWidth }) =>
+    fullWidth
+      ? css`
+          flex: 1;
+        `
+      : css`
+          width: 20rem;
+        `};
+  /* width: ${({ fullWidth }) => (fullWidth ? '100%' : '20rem')}; */
 `;
 
 const BigWhiteInput = styled(Input)<AddressProps>`
-  width: ${({ width }) => (width ? '100%' : '20rem')};
+  ${({ fullWidth }) =>
+    fullWidth
+      ? css`
+          flex: 1;
+        `
+      : css`
+          width: 20rem;
+        `};
+  /* width: ${({ fullWidth }) => (fullWidth ? '100%' : '20rem')}; */
 `;
 
-const Address = ({ width }: AddressProps) => {
+const Address = ({ fullWidth }: AddressProps) => {
   return (
     <AddressStyle>
       <div>
         <SmallInput type="text" placeholder="우편번호" />
         <DoubleCheckButton>중복확인</DoubleCheckButton>
       </div>
-      <BigInput type="text" placeholder="기본주소" width={width} />
-      <BigWhiteInput type="text" width={width} />
+      <BigInput type="text" placeholder="기본주소" fullWidth={fullWidth} />
+      <BigWhiteInput type="text" fullWidth={fullWidth} />
     </AddressStyle>
   );
 };

--- a/src/components/purchase/PurchaseInformation.tsx
+++ b/src/components/purchase/PurchaseInformation.tsx
@@ -28,7 +28,7 @@ const Content = styled.div`
 `;
 
 const WidthInput = styled(Input)`
-  width: 100%;
+  flex: 1;
 `;
 
 const Check = styled.div`
@@ -120,7 +120,7 @@ const PurchaseInformation = () => {
       </Content>
       <Content>
         <SubTitle>주소</SubTitle>
-        <Address width={true} />
+        <Address />
       </Content>
       <Content>
         <SubTitle>휴대전화</SubTitle>


### PR DESCRIPTION
### 관련 이슈
- close #52 

### PR Checklist
- [x] width는 직관적으로 fullWidth로 바꿈
- [x] bool 값은 속성으로 전해줄 수 없으므로 다른 방식으로 해야 함
- [x] flex일 때 요소가 전체를 꽉 차지하게 하려면 width 100%가 아닌 flex-grow: 1(flex: 1)을 해야함

### 테스트 결과
<img width="674" alt="스크린샷 2023-09-12 오전 3 16 04" src="https://github.com/Kusitms-28th-Hicardi-C/FrontEnd/assets/77859988/da010a62-551f-48c8-9fb2-abb001f64602">
